### PR TITLE
feat: complete CRUD for single job application by ID (#15)

### DIFF
--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Body
 from sqlalchemy.orm import Session
 from app.crud import job_crud
 from app.api.deps import get_db
@@ -26,8 +26,13 @@ def read_jobs_by_id(id: int, db: Session = Depends(get_db)):
 @router.put("/{id}", response_model=job_schemas.JobApp)
 def update_jobs_by_id(
         id: int,
+        # This injects a SQLAlchemy database session using FastAPIs dependency injection system.
         db: Session = Depends(get_db),
-        updated_data=job_schemas.JobAppUpdate):
+        # This is the body of the request, expected to be JSON.
+        # FastAPI will parse it using the JobAppUpdate Pydantic schema.
+        # = Body(...) means this field is required, and will come from the body of the PUT request.
+        updated_data: job_schemas.JobAppUpdate = Body(...),
+):
     return job_crud.update_job(db, id, updated_data)
 
 

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -15,3 +15,9 @@ def create_application(job: job_schemas.JobAppCreate, db: Session = Depends(get_
 @router.get("/", response_model=list[job_schemas.JobApp])
 def read_applications(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
     return job_crud.get_job_apps(db, skip=skip, limit=limit)
+
+
+@router.get("/{id}", response_model=job_schemas.JobApp)
+def read_jobs_by_id(id: int, db: Session = Depends(get_db)):
+    job_app = job_crud.get_job_app_by_id(db, id)
+    return job_app

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -29,3 +29,8 @@ def update_jobs_by_id(
         db: Session = Depends(get_db),
         updated_data=job_schemas.JobAppUpdate):
     return job_crud.update_job(db, id, updated_data)
+
+@router.delete("/{id}", response_model=job_schemas.JobApp)
+def delete_jobs_by_id(id: int, db: Session = Depends(get_db)):
+    job_crud.delete_job(db, id)
+    return {"detail": f"Successfully deleted job ID {id} 💀"}

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -36,7 +36,7 @@ def update_jobs_by_id(
     return job_crud.update_job(db, id, updated_data)
 
 
-@router.delete("/{id}", response_model=job_schemas.JobApp)
+@router.delete("/{id}", response_model=None)
 def delete_jobs_by_id(id: int, db: Session = Depends(get_db)):
     job_crud.delete_job(db, id)
-    return {"detail": f"Successfully deleted job ID {id} 💀"}
+    return None

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -21,3 +21,11 @@ def read_applications(skip: int = 0, limit: int = 10, db: Session = Depends(get_
 def read_jobs_by_id(id: int, db: Session = Depends(get_db)):
     job_app = job_crud.get_job_app_by_id(db, id)
     return job_app
+
+
+@router.put("/{id}", response_model=job_schemas.JobApp)
+def update_jobs_by_id(
+        id: int,
+        db: Session = Depends(get_db),
+        updated_data=job_schemas.JobAppUpdate):
+    return job_crud.update_job(db, id, updated_data)

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -30,6 +30,7 @@ def update_jobs_by_id(
         updated_data=job_schemas.JobAppUpdate):
     return job_crud.update_job(db, id, updated_data)
 
+
 @router.delete("/{id}", response_model=job_schemas.JobApp)
 def delete_jobs_by_id(id: int, db: Session = Depends(get_db)):
     job_crud.delete_job(db, id)

--- a/app/crud/job_crud.py
+++ b/app/crud/job_crud.py
@@ -42,19 +42,28 @@ def delete_job(db: Session, job_id: int):
     return job
 
 
-# Do partial updates
+# Accepts a DB session, job ID, and partial update data using a Pydantic schema
 def update_job(db: Session, job_id: int, updated_data: schemas.JobAppUpdate):
+    #  Fetch the job entry from the database
     job = db.query(models.JobApplication).filter(models.JobApplication.id == job_id).first()
+
+    #  If it doesn't exist, raise 404
     if not job:
         logger.warning(f"⚠️ Tried to update missing job ID {job_id}")
         raise HTTPException(status_code=404, detail="Job wasn't found 💀")
 
+    #  Update only the fields that were actually passed in the request
     for key, value in updated_data.dict(exclude_unset=True).items():
         setattr(job, key, value)
 
+    #  Save and refresh the changes in the DB
     db.commit()
     db.refresh(job)
+
+    #  Log what got updated
     logger.info(f"✏️ Updated job ID {job_id} with fields: {list(updated_data.dict(exclude_unset=True).keys())}")
+
+    #  Return the fully updated model
     return job
 
 

--- a/app/crud/job_crud.py
+++ b/app/crud/job_crud.py
@@ -56,3 +56,11 @@ def update_job(db: Session, job_id: int, updated_data: schemas.JobAppUpdate):
     db.refresh(job)
     logger.info(f"✏️ Updated job ID {job_id} with fields: {list(updated_data.dict(exclude_unset=True).keys())}")
     return job
+
+
+def get_job_app_by_id(db: Session, id: int):
+    job = db.query(models.JobApplication).filter(models.JobApplication.id == id).first()
+    if not job:
+        logger.warning(f"⚠️ Tried to find non-existent ID {id}")
+        raise HTTPException(status_code=404, detail="Job wasn't found 💀")
+    return job

--- a/app/schemas/job_schemas.py
+++ b/app/schemas/job_schemas.py
@@ -46,7 +46,7 @@ class JobApp(JobAppBase):
 # For partial updates (PATCH/PUT)
 # This lets the user update only one field
 # without sending the whole object.
-class JobAppUpdate:
+class JobAppUpdate(JobAppBase):
     company: Optional[str] = None,
     position: Optional[str] = None
     location: Optional[str] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,8 @@ from app.main import app  # 🚀 The actual FastAPI app object being tested
 from app.models.job_models import JobApplication  # import JobApplication model
 import datetime  # Import Python's date class to pass a date object instead of a string
 
-from app.api.deps import get_db
-from app.db.database import Base
-from app.main import app
+# # Use separate SQLite DB for testing separately from prod one
+SQLALCHEMY_TEST_DB_URL = "sqlite:///./test.db"
 
 # Create engine that connects to the test DB
 # "check_same_thread=False" is needed because SQLite is single-threaded by default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,9 +51,10 @@ def client(db):  # 👈 db fixture is passed in, so every test gets a fresh sess
     # Patch the app so that all routes now use test DB session
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app) as c:
-        yield c
-    app.dependency_overrides.clear()
+    with TestClient(app) as c:  #  Simulate HTTP requests
+        yield c  # Provide this test client to the test
+    app.dependency_overrides.clear()  # Reset dependency overrides after test
+
 
 @pytest.fixture(scope="function")
 def sample_applications(db):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,24 @@
 # Create fresh DB(mock) for testing (Shared Test Setup)
-import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+import pytest  # 🧪 Pytest framework for writing and managing tests
+from fastapi.testclient import TestClient  # 🚀 Used to simulate requests to FastAPI app in tests
+from sqlalchemy import create_engine  # ⚙️ To create a DB connection
+from sqlalchemy.orm import sessionmaker  # 🧵 For managing sessions to the DB
+from app.api.deps import get_db  # 🧩 The FastAPI dependency I override in tests
+from app.db.database import Base  # 🧱 SQLAlchemy models’ Base (used to create/drop tables)
+from app.main import app  # 🚀 The actual FastAPI app object being tested
+from app.models.job_models import JobApplication  # import JobApplication model
+import datetime  # Import Python's date class to pass a date object instead of a string
 
 from app.api.deps import get_db
 from app.db.database import Base
 from app.main import app
 
-# # Use in-memory SQLite DB
-SQLALCHEMY_TEST_DB_URL = "sqlite:///:memory:"
-
+# Create engine that connects to the test DB
+# "check_same_thread=False" is needed because SQLite is single-threaded by default
 engine = create_engine(SQLALCHEMY_TEST_DB_URL, connect_args={"check_same_thread": False})
+
+# Create a session factory bound to this test engine
+# autocommit=False, autoflush=False = better control over transactions
 TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 
@@ -20,26 +27,29 @@ def db():
     # 1. Setup: create all tables fresh in the test DB engine
     Base.metadata.create_all(bind=engine)  # engine is the test engine, not prod
 
+    # Create a session to talk to this fresh test DB
     session = TestingSessionLocal()
 
     # 2. Yield: hand over the session for test to use
     try:
+        # 🎯 Provide this DB session to tests via yield
         yield session
     finally:
-        # 3. Teardown: clean up after test
+        # 3. Teadrown: close the session and drop all tables (clean state)
         session.close()
         Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture(scope="function")
-def client(db):
-    #  override get_db to return session fixture
+def client(db):  # 👈 db fixture is passed in, so every test gets a fresh session
+    # This overrides the normal FastAPI DB dependency with the test session
     def override_get_db():
         try:
-            yield db
+            yield db  # 🔁 Yield the test session instead of the real one
         finally:
             pass
 
+    # Patch the app so that all routes now use test DB session
     app.dependency_overrides[get_db] = override_get_db
 
     with TestClient(app) as c:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,3 +54,20 @@ def client(db):  # 👈 db fixture is passed in, so every test gets a fresh sess
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+
+@pytest.fixture(scope="function")
+def sample_applications(db):
+    # Create one fake job application
+    job = JobApplication(
+        company="TestCompany",
+        position="Python Developer",
+        location="Remote",
+        status="applied",
+        applied_date=datetime.date(2025, 1, 1),
+        link="http://example.com",
+        notes="FastAPI FTW"
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)  # to get the ID
+    return [job]  # return it so you can use it in your tests if needed

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -36,7 +36,7 @@ def test_delete_nonexistent_job(db):
 def test_delete_nonexistent_job_endpoint(client):
     response = client.delete("/applications/999")
     assert response.status_code == 404
-    assert response.json() == {"detail": "Not Found"}
+    assert response.json() == {'detail': "Job wasn't found 💀"}
 
 
 def test_feed_schema_invalid_status(db):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,10 +2,12 @@
 from app.models.job_models import JobApplication
 import datetime
 
+
 def test_read_root(client):
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Job Application Tracker is up and running 🚀"}
+
 
 # This test checks if the /applications/ endpoint returns a successful response
 def test_read_applications_route(client):
@@ -60,3 +62,29 @@ def test_update_job_application_by_id(client, db):
     data = get_response.json()
     assert data["status"] == "interviewing"
     assert data["notes"] == "waiting for reply"
+
+
+# This test verifies the logic of updating job application by the ID
+def test_delete_job_application_by_id(client, db):
+    # Create the original job app in the DB
+    job_app = JobApplication(
+        company="OriginalCo",
+        position="Backend Engineer",
+        location="NYC",
+        status="applied",
+        applied_date=datetime.date(2025, 5, 1),
+        link="http://original.com",
+        notes="initial notes"
+    )
+    db.add(job_app)
+    db.commit()
+    db.refresh(job_app)
+
+    # Send PUT or PATCH request to update the job app
+    response = client.delete(f"/applications/{job_app.id}")
+
+    assert response.status_code == 200
+
+    # Check DB: job should not exist anymore
+    deleted_job = db.query(JobApplication).filter(JobApplication.id == job_app.id).first()
+    assert deleted_job is None

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,4 +1,6 @@
 # Route Testing with FastAPIs TestClient
+from app.models.job_models import JobApplication
+import datetime
 
 def test_read_root(client):
     response = client.get("/")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,3 +23,38 @@ def test_read_applications_route_with_id(client, sample_applications):
 def test_access_non_existent_job_id(client):
     response = client.get("/applications/9999/")
     assert response.status_code == 404
+
+
+# This test verifies the logic of updating job details by the ID
+def test_update_job_application_by_id(client, db):
+    # Create the original job app in the DB
+    job_app = JobApplication(
+        company="OriginalCo",
+        position="Backend Engineer",
+        location="NYC",
+        status="applied",
+        applied_date=datetime.date(2025, 5, 1),
+        link="http://original.com",
+        notes="initial notes"
+    )
+    db.add(job_app)
+    db.commit()
+    db.refresh(job_app)
+
+    # Prepare the update payload
+    update_data = {
+        "status": "interviewing",
+        "applied_date": "2025-05-02",  # Here send string in API, let Pydantic parse it
+        "link": "http://updated.com",
+        "notes": "waiting for reply"
+    }
+
+    # Send PUT or PATCH request to update the job app
+    response = client.put(f"/applications/{job_app.id}/", json=update_data)
+    assert response.status_code == 200
+
+    # Verify the update was successful by fetching the updated object
+    get_response = client.get(f"/applications/{job_app.id}/")
+    data = get_response.json()
+    assert data["status"] == "interviewing"
+    assert data["notes"] == "waiting for reply"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -17,3 +17,9 @@ def test_read_applications_route_with_id(client, sample_applications):
     assert response.status_code == 200
     data = response.json()
     assert data["company"] == "TestCompany"
+
+
+# This test verifies that requesting a non-existent job application ID returns a 404 error
+def test_access_non_existent_job_id(client):
+    response = client.get("/applications/9999/")
+    assert response.status_code == 404

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,3 +9,11 @@ def test_read_root(client):
 def test_read_applications_route(client):
     response = client.get("/applications/")
     assert response.status_code == 200
+
+
+# This test checks if fetching a specific job application by ID returns correct data
+def test_read_applications_route_with_id(client, sample_applications):
+    response = client.get("/applications/1/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["company"] == "TestCompany"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -4,3 +4,8 @@ def test_read_root(client):
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Job Application Tracker is up and running 🚀"}
+
+# This test checks if the /applications/ endpoint returns a successful response
+def test_read_applications_route(client):
+    response = client.get("/applications/")
+    assert response.status_code == 200


### PR DESCRIPTION
Description:
This PR extends the Job Application Tracker API to fully support retrieving, updating, and deleting a single job application by its ID, completing the CRUD functionality.

Implemented:

✅ Routes (job_routes.py)
GET /applications/{id} — retrieve a single job application
PUT /applications/{id} — update a job application
DELETE /applications/{id} — delete a job application

✅ CRUD logic (job_crud.py)
get_job_app_by_id(db, id)
update_job_app(db, id, job)
delete_job_app(db, id)

✅ Tests (tests/test_routes.py)
Test GET single application by ID
Test PUT update application by ID
Test DELETE application by ID
Test 404 error on non-existent ID

Closes #15 .