### PR TITLE
Pull Request: Improve Test Coverage & Fix Pydantic v2 Compatibility

### DIFF
--- a/app/crud/job_crud.py
+++ b/app/crud/job_crud.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # Handle creating a new row in the job_applications table.
 def create_job_app(db: Session, job: schemas.JobAppCreate):
-    job_data_dict = job.dict()
+    job_data_dict = job.model_dump()
     if job_data_dict["link"] is not None:
         job_data_dict["link"] = str(job_data_dict["link"])
 
@@ -53,7 +53,7 @@ def update_job(db: Session, job_id: int, updated_data: schemas.JobAppUpdate):
         raise HTTPException(status_code=404, detail="Job wasn't found 💀")
 
     #  Update only the fields that were actually passed in the request
-    for key, value in updated_data.dict(exclude_unset=True).items():
+    for key, value in updated_data.model_dump(exclude_unset=True).items():
         setattr(job, key, value)
 
     #  Save and refresh the changes in the DB
@@ -61,7 +61,7 @@ def update_job(db: Session, job_id: int, updated_data: schemas.JobAppUpdate):
     db.refresh(job)
 
     #  Log what got updated
-    logger.info(f"✏️ Updated job ID {job_id} with fields: {list(updated_data.dict(exclude_unset=True).keys())}")
+    logger.info(f"✏️ Updated job ID {job_id} with fields: {list(updated_data.model_dump(exclude_unset=True).keys())}")
 
     #  Return the fully updated model
     return job

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -25,6 +25,14 @@ def test_get_job_apps_empty(db):
     assert apps == []
 
 
+def test_get_job_app_by_id_raises_404(db):
+    # Try to get a job application with an ID that doesn't exist
+    with pytest.raises(HTTPException) as exc_info:
+        job_crud.get_job_app_by_id(db, id=999999)
+    assert exc_info.value.status_code == 404
+    assert "job wasn't found 💀" in exc_info.value.detail.lower()
+
+
 def test_delete_nonexistent_job(db):
     with pytest.raises(HTTPException) as ex_info:
         job_crud.delete_job(db, job_id=99999)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -47,6 +47,21 @@ def test_delete_nonexistent_job_endpoint(client):
     assert response.json() == {'detail': "Job wasn't found 💀"}
 
 
+def test_update_nonexistent_job(db):
+    # Create a fake update payload
+    update_info = job_schemas.JobAppUpdate(
+        company="Ghost Corp",
+        position="No code Engineer"
+    )
+
+    # Act & Assert: expect HTTPException with 404
+    with pytest.raises(HTTPException) as exc_info:
+        job_crud.update_job(db, job_id=9999, updated_data=update_info)
+
+    assert exc_info.value.status_code == 404
+    assert "Job wasn't found 💀" in str(exc_info.value.detail)
+
+
 def test_feed_schema_invalid_status(db):
     with pytest.raises(ValidationError) as ex_info:
         job_schemas.JobAppCreate(

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,16 @@
+from app.api.deps import get_db
+
+
+# Testing for dependency logic.
+def test_get_db(db):
+    gen = get_db()  # call your generator dependency
+    db = next(gen)  # get the yielded session
+
+    assert db is not None
+    from app.db.database import SessionLocal
+    assert isinstance(db, SessionLocal().__class__)
+
+    try:
+        next(gen)  # run cleanup
+    except StopIteration:
+        pass

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -29,6 +29,27 @@ def test_access_non_existent_job_id(client):
     assert response.status_code == 404
 
 
+def test_create_job_application(client):
+    new_job = {
+        "company": "OpenAI",
+        "position": "Prompt Engineer",
+        "status": "applied",
+        "applied_date": "2024-05-18",
+        "link": "https://openai.com/careers",
+        "notes": "Excited about LLMs!"
+    }
+
+    response = client.post("/applications/", json=new_job)
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    assert data["company"] == new_job["company"]
+    assert data["position"] == new_job["position"]
+    assert data["status"] == new_job["status"]
+    assert data["applied_date"] == new_job["applied_date"]
+    isinstance(data["id"], int)
+
+
 # This test verifies the logic of updating job details by the ID
 def test_update_job_application_by_id(client, db):
     # Create the original job app in the DB


### PR DESCRIPTION
What’s new:
test(deps): Added unit test for the get_db dependency session generator to ensure proper DB session yield and cleanup.
test(routes): Added integration test for creating a new job application via POST /applications/.

test(crud):
Added test for raising 404 when updating a nonexistent job application.
Added test for raising 404 when retrieving a nonexistent job application.
fix(crud): Replaced deprecated .dict() with .model_dump() in CRUD update logic to comply with Pydantic v2 requirements.

Why it matters:
Increases test coverage for critical CRUD operations and API routes.
Prevents regressions in DB session management during testing.
Ensures codebase is compatible with latest Pydantic version, avoiding future runtime errors.
Strengthens reliability and robustness of your Job Application Tracker API.

