### PR TITLE
Chore/add init files optimize imports 

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -10,7 +10,7 @@ from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from alembic import context
-from app.models.job_models import Base
+from app.db import Base
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,5 @@
+from .deps import get_db
+
+__all__ =[
+    "get_db"
+]

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,15 @@
+from .job_crud import (
+    create_job_app,
+    delete_job,
+    get_job_apps,
+    get_job_app_by_id,
+    update_job,
+)
+
+__all__ = [
+    "create_job_app",
+    "delete_job",
+    "get_job_apps",
+    "get_job_app_by_id",
+    "update_job",
+]

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,7 @@
+from .base import Base
+from .database import SessionLocal, engine
+
+__all__ = ["Base", "SessionLocal", "engine"]
+
+# Import all the models to make sure they're registered with Base
+from app.models import job_models

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,4 @@
+from sqlalchemy.orm import declarative_base
+
+# Base class for SQLAlchemy models
+Base = declarative_base()

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -2,7 +2,6 @@
 import os
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 # Load environment variables from .env
@@ -20,5 +19,3 @@ engine = create_engine(
 # Session maker for handling DB sessions
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# Base class for SQLAlchemy models
-Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI
 
 from app.api.routes import job_routes
-from app.db.database import engine
+from app.db import engine
 from app.models import job_models
 
 from sqlalchemy.exc import IntegrityError

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,5 @@
+from .job_models import JobApplication
+
+__all__ = [
+    "JobApplication"
+]

--- a/app/models/job_models.py
+++ b/app/models/job_models.py
@@ -3,8 +3,7 @@
 # defining how Python classes = database tables.
 
 from sqlalchemy import Column, Integer, String, Date
-from app.db.database import Base
-from app.schemas.job_schemas import ApplicationStatus
+from app.db import Base
 from app.schemas import ApplicationStatus
 from sqlalchemy import Enum as SQLEnum
 

--- a/app/models/job_models.py
+++ b/app/models/job_models.py
@@ -5,6 +5,7 @@
 from sqlalchemy import Column, Integer, String, Date
 from app.db.database import Base
 from app.schemas.job_schemas import ApplicationStatus
+from app.schemas import ApplicationStatus
 from sqlalchemy import Enum as SQLEnum
 
 

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,6 @@
+from .job_schemas import JobAppBase, JobAppCreate, JobApp, JobAppUpdate, ApplicationStatus
+
+__all__ = [
+    "JobAppBase", "JobAppCreate", "JobApp",
+    "JobAppUpdate", "ApplicationStatus"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,10 @@ import pytest  # 🧪 Pytest framework for writing and managing tests
 from fastapi.testclient import TestClient  # 🚀 Used to simulate requests to FastAPI app in tests
 from sqlalchemy import create_engine  # ⚙️ To create a DB connection
 from sqlalchemy.orm import sessionmaker  # 🧵 For managing sessions to the DB
-from app.api.deps import get_db  # 🧩 The FastAPI dependency I override in tests
-from app.db.database import Base  # 🧱 SQLAlchemy models’ Base (used to create/drop tables)
+from app.api import get_db  # 🧩 The FastAPI dependency I override in tests
+from app.db import Base  # 🧱 SQLAlchemy models’ Base (used to create/drop tables)
 from app.main import app  # 🚀 The actual FastAPI app object being tested
-from app.models.job_models import JobApplication  # import JobApplication model
+from app.models import JobApplication  # import JobApplication model
 import datetime  # Import Python's date class to pass a date object instead of a string
 
 # # Use separate SQLite DB for testing separately from prod one
@@ -51,7 +51,7 @@ def client(db):  # 👈 db fixture is passed in, so every test gets a fresh sess
     # Patch the app so that all routes now use test DB session
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app) as c:  #  Simulate HTTP requests
+    with TestClient(app) as c:  # Simulate HTTP requests
         yield c  # Provide this test client to the test
     app.dependency_overrides.clear()  # Reset dependency overrides after test
 


### PR DESCRIPTION
### Added `__init__.py` files to treat all relevant directories as Python packages

This upgrade improves internal consistency, enables relative and absolute imports across modules, and makes the project more modular and testable.

**Why this matters:**
- Unifies import paths across `app/`, `schemas/`, `crud/`, `models/`, and `db/`
- Ensures compatibility with tools like `pytest`, `alembic`, and IDEs like PyCharm
- Unblocks future refactors like splitting concerns, adding user auth, etc.

📦 Affected folders:
- `app/api/routes`
- `app/crud`
- `app/models`
- `app/schemas`
- `app/db`

✅ Follow-up:
- Clean up broken import paths if any still exist
- Confirm `python -m app.main` runs smoothly