### PR TITLE
Complete async test coverage for user and job routes with isolated DB

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,9 +1,29 @@
-from app.db.database import SessionLocal
+from app.db.database import SessionLocal, AsyncSessionLocal
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def get_db():
+    """
+        Sync DB session dependency.
+        Yields a normal Session, then closes it.
+        Use in `def` endpoints.
+    """
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
+
+async def get_async_db():
+    """
+        Async DB session dependency.
+        Yields an AsyncSession, then closes it.
+        Use in `async def` endpoints.
+    """
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            # ensure all cleanup is done
+            await session.close()

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -5,7 +5,6 @@ from app.api.deps import get_async_db
 from app.schemas import job_schemas
 
 router = APIRouter(
-    prefix="/applications",
     tags=["Applications"]
 )
 

--- a/app/api/routes/job_routes.py
+++ b/app/api/routes/job_routes.py
@@ -1,42 +1,45 @@
-from fastapi import APIRouter, Depends, Body
-from sqlalchemy.orm import Session
+from fastapi import APIRouter, Depends, Body, Response
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.crud import job_crud
-from app.api.deps import get_db
+from app.api.deps import get_async_db
 from app.schemas import job_schemas
 
-router = APIRouter()
+router = APIRouter(
+    prefix="/applications",
+    tags=["Applications"]
+)
 
 
-@router.post("/", response_model=job_schemas.JobApp)
-def create_application(job: job_schemas.JobAppCreate, db: Session = Depends(get_db)):
-    return job_crud.create_job_app(db=db, job=job)
+@router.post("/", response_model=job_schemas.JobApp, status_code=201)
+async def create_application(job: job_schemas.JobAppCreate, db: AsyncSession = Depends(get_async_db)):
+    return await job_crud.create_job_app(db=db, job=job)
 
 
 @router.get("/", response_model=list[job_schemas.JobApp])
-def read_applications(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
-    return job_crud.get_job_apps(db, skip=skip, limit=limit)
+async def read_applications(skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_async_db)):
+    return await job_crud.get_job_apps(db, skip=skip, limit=limit)
 
 
 @router.get("/{id}", response_model=job_schemas.JobApp)
-def read_jobs_by_id(id: int, db: Session = Depends(get_db)):
-    job_app = job_crud.get_job_app_by_id(db, id)
+async def read_jobs_by_id(id: int, db: AsyncSession = Depends(get_async_db)):
+    job_app = await job_crud.get_job_app_by_id(db, id)
     return job_app
 
 
-@router.put("/{id}", response_model=job_schemas.JobApp)
-def update_jobs_by_id(
+@router.put("/{id}", response_model=job_schemas.JobApp, status_code=200)
+async def update_jobs_by_id(
         id: int,
         # This injects a SQLAlchemy database session using FastAPIs dependency injection system.
-        db: Session = Depends(get_db),
+        db: AsyncSession = Depends(get_async_db),
         # This is the body of the request, expected to be JSON.
         # FastAPI will parse it using the JobAppUpdate Pydantic schema.
         # = Body(...) means this field is required, and will come from the body of the PUT request.
         updated_data: job_schemas.JobAppUpdate = Body(...),
 ):
-    return job_crud.update_job(db, id, updated_data)
+    return await job_crud.update_job(db, id, updated_data)
 
 
-@router.delete("/{id}", response_model=None)
-def delete_jobs_by_id(id: int, db: Session = Depends(get_db)):
-    job_crud.delete_job(db, id)
-    return None
+@router.delete("/{id}", response_model=None, status_code=204)
+async def delete_jobs_by_id(id: int, db: AsyncSession = Depends(get_async_db)):
+    await job_crud.delete_job(db, id)
+    return

--- a/app/api/routes/user_routes.py
+++ b/app/api/routes/user_routes.py
@@ -1,52 +1,55 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
-
-from app.api.deps import get_db
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.api.deps import get_async_db
 
 from app.schemas import user_schemas
 from app.crud import user_crud
 
-router = APIRouter()
+router = APIRouter(
+    prefix="/users",
+    tags=["Users"]
+)
 
 
 # Register a user
-@router.post("/register", response_model=user_schemas.User)
-def create_user(user: user_schemas.UserCreate, db: Session = Depends(get_db)):
-    return user_crud.create_user(db, user)
+@router.post("/register", response_model=user_schemas.User, status_code=201)
+async def create_user(user: user_schemas.UserCreate, db: AsyncSession = Depends(get_async_db)):
+    return await user_crud.create_user(db, user)
 
 
 @router.get("/", response_model=list[user_schemas.User])
-def read_applications(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
-    return user_crud.get_users(db, skip=skip, limit=limit)
+async def read_users(skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_async_db)):
+    return await user_crud.get_users(db, skip=skip, limit=limit)
+
+
+# GET /users/username/{username} for user-friendly URLs
+@router.get("/username/{username}", response_model=user_schemas.UserBase)
+async def get_user_by_username(username: str, db: AsyncSession = Depends(get_async_db)):
+    user = await user_crud.get_user_by_username(db, username)
+    return user
 
 
 # GET /users/{user_id} for internal logic (auth, DB operations)
 @router.get("/{user_id}", response_model=user_schemas.User)
-def get_user_by_id(user_id: str, db: Session = Depends(get_db)):
+async def get_user_by_id(user_id: str, db: AsyncSession = Depends(get_async_db)):
     try:
         _ = UUID(user_id)  # Just to validate the UUID format because SQLite stores uuid as text
-        user = user_crud.get_user_by_id(db, user_id)
+        user = await user_crud.get_user_by_id(db, user_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid UUID format.")
     return user
 
 
-# GET /users/username/{username} for user-friendly URLs
-@router.get("/username/{username}", response_model=user_schemas.UserBase)
-def get_user_by_username(username: str, db: Session = Depends(get_db)):
-    user = user_crud.get_user_by_username(db, username)
-    return user
-
-
 # Update user
-@router.put("/{user_id}", response_model=user_schemas.User)
-def update_user(user_id: str, user_update: user_schemas.UserUpdate, db: Session = Depends(get_db)):
-    return user_crud.update_user(db, user_id, user_update)
+@router.put("/{user_id}", response_model=user_schemas.User, status_code=200)
+async def update_user(user_id: str, user_update: user_schemas.UserUpdate, db: AsyncSession = Depends(get_async_db)):
+    return await user_crud.update_user(db, user_id, user_update)
 
 
 # Delete user
 @router.delete("/{user_id}", status_code=204)
-def delete_user(user_id: str, db: Session = Depends(get_db)):
-    user_crud.delete_user(db, user_id)
+async def delete_user(user_id: str, db: AsyncSession = Depends(get_async_db)):
+    await user_crud.delete_user(db, user_id)
+    return

--- a/app/api/routes/user_routes.py
+++ b/app/api/routes/user_routes.py
@@ -8,7 +8,6 @@ from app.schemas import user_schemas
 from app.crud import user_crud
 
 router = APIRouter(
-    prefix="/users",
     tags=["Users"]
 )
 

--- a/app/crud/job_crud.py
+++ b/app/crud/job_crud.py
@@ -1,7 +1,8 @@
 # Contains DB logic.
 
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.models.job_models as models
 import app.schemas.job_schemas as schemas
@@ -10,71 +11,91 @@ from app.exceptions import JobApplicationNotFoundException, AppBaseException
 
 
 # Handle creating a new row in the job_applications table.
-def create_job_app(db: Session, job: schemas.JobAppCreate):
+async def create_job_app(db: AsyncSession, job: schemas.JobAppCreate):
     try:
         job_data_dict = job.model_dump()
-        if job_data_dict["link"] is not None:
+
+        if "link" in job_data_dict and job_data_dict["link"] is not None:
             job_data_dict["link"] = str(job_data_dict["link"])
 
         db_job = models.JobApplication(**job_data_dict)
         db.add(db_job)
-        db.commit()
-        db.refresh(db_job)
+        await db.commit()
+        await db.refresh(db_job)
         logger.info(f"✅ Created job application: {db_job.id} at {db_job.company}")
         return db_job
     except IntegrityError:
-        db.rollback()
+        await db.rollback()
         raise AppBaseException(status_code=409, detail="Database integrity error: Duplicate or invalid data.")
+    except Exception:
+        await db.rollback()
+        raise AppBaseException(status_code=500, detail="Unexpected error during creation.")
 
 
 # List jobs with pagination
-def get_job_apps(db: Session, skip: int = 0, limit: int = 100):
+async def get_job_apps(db: AsyncSession, skip: int = 0, limit: int = 100):
     try:
-        return db.query(models.JobApplication).offset(skip).limit(limit).all()
+        result = await db.execute(
+            select(models.JobApplication).offset(skip).limit(limit)
+        )
+        logger.info(f"📄 Fetched jobs: skip={skip}, limit={limit}")
+        return result.scalars().all()
     except Exception:
         raise AppBaseException(status_code=500, detail="Internal server error while fetching job applications.")
 
 
 # Delete a job by ID
-def delete_job(db: Session, job_id: int):
+async def delete_job(db: AsyncSession, job_id: int):
     try:
-        job = db.query(models.JobApplication).filter(models.JobApplication.id == job_id).first()
+        job = await fetch_one(db, select(models.JobApplication).where(models.JobApplication.id == job_id))
         if not job:
             raise JobApplicationNotFoundException(job_id)
         db.delete(job)
-        db.commit()
+        await db.commit()
         logger.info(f"🗑️ Deleted job ID {job_id}")
         return job
     except Exception:
-        db.rollback()
+        await db.rollback()
         raise AppBaseException(status_code=500, detail="Unexpected error during deletion.")
 
 
 # Accepts a DB session, job ID, and partial update data using a Pydantic schema
-def update_job(db: Session, job_id: int, updated_data: schemas.JobAppUpdate):
+async def update_job(db: AsyncSession, job_id: int, updated_data: schemas.JobAppUpdate):
     try:
         #  Fetch the job entry from the database
-        job = get_job_app_by_id(db, job_id)
-        if not job:
-            raise JobApplicationNotFoundException(job_id)
+        job = await get_job_app_by_id(db, job_id)
+        update_fields = updated_data.model_dump(exclude_unset=True)
+
         #  Update only the fields that were actually passed in the request
-        for key, value in updated_data.model_dump(exclude_unset=True).items():
+        for key, value in update_fields.items():
             setattr(job, key, value)
         #  Save and refresh the changes in the DB
-        db.commit()
-        db.refresh(job)
+        await db.commit()
+        await db.refresh(job)
         #  Log what got updated
         logger.info(
-            f"✏️ Updated job ID {job_id} with fields: {list(updated_data.model_dump(exclude_unset=True).keys())}")
+            f"✏️ Updated job ID {job_id} with fields: {list(update_fields.keys())}")
         #  Return the fully updated model
         return job
-    except IntegrityError as e:
-        db.rollback()
+    except IntegrityError:
+        await db.rollback()
         raise AppBaseException(status_code=409, detail="Database integrity error during update.")
+    except Exception:
+        await db.rollback()
+        raise AppBaseException(status_code=500, detail="Unexpected error during update.")
 
 
-def get_job_app_by_id(db: Session, job_id: int):
-    job = db.query(models.JobApplication).filter(models.JobApplication.id == job_id).first()
+async def get_job_app_by_id(db: AsyncSession, job_id: int):
+    job = await fetch_one(db, select(models.JobApplication).where(models.JobApplication.id == job_id))
+    logger.info(f"🔎 Fetched job ID: {job_id}")
     if not job:
         raise JobApplicationNotFoundException(job_id)
     return job
+
+
+async def fetch_one(db: AsyncSession, stmt) -> models.JobApplication | None:
+    """
+        Executes the provided SQLAlchemy select() statement and returns a single ORM object or None.
+    """
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()

--- a/app/crud/user_crud.py
+++ b/app/crud/user_crud.py
@@ -58,7 +58,7 @@ async def delete_user(db: AsyncSession, user_id: str):
         user = await fetch_user(db, select(models.User).where(models.User.id == user_id))
         if not user:
             raise UserNotFoundException
-        db.delete(user)
+        await db.delete(user)
         await db.commit()
         logger.info(f"🗑️ Deleted user with ID {user_id}")
         return user

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -2,6 +2,7 @@
 import os
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Load environment variables from .env
@@ -10,12 +11,33 @@ load_dotenv()
 # Grab the DB URL from the environment
 SQLALCHEMY_DATABASE_URL = os.getenv("DB_URL")
 
+# Derive your sync & async URLs - declare as constants
+SYNC_DB_URL = SQLALCHEMY_DATABASE_URL
+ASYNC_DB_URL = SYNC_DB_URL.replace("sqlite://", "sqlite+aiosqlite://")
+
 # Create the engine — with special SQLite handling
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL,
-    connect_args={"check_same_thread": False} if "sqlite" in SQLALCHEMY_DATABASE_URL else {}
+    SYNC_DB_URL,
+    connect_args={"check_same_thread": False} if "sqlite" in SYNC_DB_URL else {}
 )
 
-# Session maker for handling DB sessions
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+# Create the async engine
+async_engine = create_async_engine(
+    ASYNC_DB_URL,
+    connect_args={"check_same_thread": False} if "sqlite" in ASYNC_DB_URL else {},
+)
 
+# Session makers
+SessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=engine)
+
+# AsyncSession factory
+AsyncSessionLocal = sessionmaker(
+    bind=async_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False,
+    autocommit=False,
+)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,63 +1,72 @@
 # Create fresh DB(mock) for testing (Shared Test Setup)
-import pytest  # 🧪 Pytest framework for writing and managing tests
-from fastapi.testclient import TestClient  # 🚀 Used to simulate requests to FastAPI app in tests
-from sqlalchemy import create_engine  # ⚙️ To create a DB connection
-from sqlalchemy.orm import sessionmaker  # 🧵 For managing sessions to the DB
-from app.api import get_db  # 🧩 The FastAPI dependency I override in tests
-from app.db import Base  # 🧱 SQLAlchemy models’ Base (used to create/drop tables)
-from app.main import app  # 🚀 The actual FastAPI app object being tested
-from app.models import JobApplication, User  # import JobApplication and User models
 import datetime  # Import Python's date class to pass a date object instead of a string
+import pytest  # Pytest framework for writing and managing tests
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+from app.api.deps import get_async_db  # The FastAPI dependency I override in tests
+from app.db import Base  # SQLAlchemy models’ Base (used to create/drop tables)
+from app.main import app  # The actual FastAPI app object being tested
+from app.models import JobApplication, User  # import JobApplication and User DB models
 
 # # Use separate SQLite DB for testing separately from prod one
-SQLALCHEMY_TEST_DB_URL = "sqlite:///./test.db"
+SQLALCHEMY_TEST_DB_URL = "sqlite+aiosqlite:///./test.db"
 
 # Create engine that connects to the test DB
 # "check_same_thread=False" is needed because SQLite is single-threaded by default
-engine = create_engine(SQLALCHEMY_TEST_DB_URL, connect_args={"check_same_thread": False})
-
-# Create a session factory bound to this test engine
+engine = create_async_engine(
+    SQLALCHEMY_TEST_DB_URL,
+    connect_args={"check_same_thread": False}
+)
+# Create a session factory bound to this test engine (used for test sessions)
 # autocommit=False, autoflush=False = better control over transactions
-TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+AsyncTestingSessionLocal = async_sessionmaker(
+    bind=engine,
+    expire_on_commit=False,
+    class_=AsyncSession)
 
 
-@pytest.fixture(scope="function")
-def db():
-    # 1. Setup: create all tables fresh in the test DB engine
-    Base.metadata.create_all(bind=engine)  # engine is the test engine, not prod
+# anyio_backend: Required by pytest-anyio to work with asyncio
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
 
-    # Create a session to talk to this fresh test DB
-    session = TestingSessionLocal()
 
-    # 2. Yield: hand over the session for test to use
-    try:
-        # 🎯 Provide this DB session to tests via yield
+# 🔁 Override the actual get_async_db dependency with test DB
+async def override_get_async_db():
+    async with AsyncTestingSessionLocal() as session:
         yield session
-    finally:
-        # 3. Teadrown: close the session and drop all tables (clean state)
-        session.close()
-        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def set_dependency_override():
+    app.dependency_overrides[get_async_db] = override_get_async_db
+
+
+# 🏗️ Create schema for testing -  Create + Drop tables before/after test session
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_test_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)  # Create tables
+    yield
+    # Optionally tear down
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.fixture
+async def db_session():
+    async with AsyncTestingSessionLocal() as session:
+        yield session
+
+
+@pytest.fixture
+async def async_client():
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        yield client
 
 
 @pytest.fixture(scope="function")
-def client(db):  # 👈 db fixture is passed in, so every test gets a fresh session
-    # This overrides the normal FastAPI DB dependency with the test session
-    def override_get_db():
-        try:
-            yield db  # 🔁 Yield the test session instead of the real one
-        finally:
-            pass
-
-    # Patch the app so that all routes now use test DB session
-    app.dependency_overrides[get_db] = override_get_db
-
-    with TestClient(app) as c:  # Simulate HTTP requests
-        yield c  # Provide this test client to the test
-    app.dependency_overrides.clear()  # Reset dependency overrides after test
-
-
-@pytest.fixture(scope="function")
-def sample_applications(db):
+async def sample_applications(db_session):
     # Create one fake job application
     job = JobApplication(
         company="TestCompany",
@@ -68,14 +77,14 @@ def sample_applications(db):
         link="http://example.com",
         notes="FastAPI FTW"
     )
-    db.add(job)
-    db.commit()
-    db.refresh(job)  # to get the ID
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)  # to get the ID
     return [job]  # return it so you can use it in your tests if needed
 
 
 @pytest.fixture(scope="function")
-def sample_user(db):
+async def sample_user(db_session):
     # Create one fake job application
     user = User(
         email="example@gmail.com",
@@ -86,7 +95,7 @@ def sample_user(db):
         created_at=datetime.date(2025, 5, 23),
         last_login=None
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)  # to get the ID
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)  # to get the ID
     return [user]  # return it so you can use it in your tests if needed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ AsyncTestingSessionLocal = async_sessionmaker(
 
 
 # anyio_backend: Required by pytest-anyio to work with asyncio
-@pytest.fixture
+@pytest.fixture(scope="session")
 def anyio_backend():
     return 'asyncio'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # Create fresh DB(mock) for testing (Shared Test Setup)
 import datetime  # Import Python's date class to pass a date object instead of a string
 import pytest  # Pytest framework for writing and managing tests
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 
 from app.api.deps import get_async_db  # The FastAPI dependency I override in tests
@@ -61,7 +61,8 @@ async def db_session():
 
 @pytest.fixture
 async def async_client():
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from app.models import JobApplication, User  # import JobApplication and User DB
 from sqlalchemy import delete
 
 # # Use separate SQLite DB for testing separately from prod one
-SQLALCHEMY_TEST_DB_URL = "sqlite+aiosqlite:///./test.db"
+SQLALCHEMY_TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
 # Create engine that connects to the test DB
 # "check_same_thread=False" is needed because SQLite is single-threaded by default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from app.api.deps import get_async_db  # The FastAPI dependency I override in te
 from app.db import Base  # SQLAlchemy models’ Base (used to create/drop tables)
 from app.main import app  # The actual FastAPI app object being tested
 from app.models import JobApplication, User  # import JobApplication and User DB models
+from sqlalchemy import delete
 
 # # Use separate SQLite DB for testing separately from prod one
 SQLALCHEMY_TEST_DB_URL = "sqlite+aiosqlite:///./test.db"
@@ -56,6 +57,10 @@ async def prepare_test_db():
 @pytest.fixture
 async def db_session():
     async with AsyncTestingSessionLocal() as session:
+        # Clear tables for test isolation
+        await session.execute(delete(JobApplication))
+        await session.execute(delete(User))
+        await session.commit()
         yield session
 
 

--- a/tests/job_applications/test_routes_job.py
+++ b/tests/job_applications/test_routes_job.py
@@ -1,35 +1,43 @@
 # Route Testing with FastAPIs TestClient
+import pytest
+
 from app.models.job_models import JobApplication
 import datetime
+from sqlalchemy import select
 
 
-def test_read_root(client):
-    response = client.get("/")
+@pytest.mark.anyio
+async def test_read_root(async_client):
+    response = await async_client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Job Application Tracker is up and running 🚀"}
 
 
 # This test checks if the /applications/ endpoint returns a successful response
-def test_read_applications_route(client):
-    response = client.get("/applications/")
+@pytest.mark.anyio
+async def test_read_applications_route(async_client):
+    response = await async_client.get("/applications/")
     assert response.status_code == 200
 
 
 # This test checks if fetching a specific job application by ID returns correct data
-def test_read_applications_route_with_id(client, sample_applications):
-    response = client.get("/applications/1/")
+@pytest.mark.anyio
+async def test_read_applications_route_with_id(async_client, sample_applications):
+    response = await async_client.get("/applications/1")
     assert response.status_code == 200
     data = response.json()
     assert data["company"] == "TestCompany"
 
 
 # This test verifies that requesting a non-existent job application ID returns a 404 error
-def test_access_non_existent_job_id(client):
-    response = client.get("/applications/9999/")
+@pytest.mark.anyio
+async def test_access_non_existent_job_id(async_client):
+    response = await async_client.get("/applications/9999")
     assert response.status_code == 404
 
 
-def test_create_job_application(client):
+@pytest.mark.anyio
+async def test_create_job_application(async_client):
     new_job = {
         "company": "OpenAI",
         "position": "Prompt Engineer",
@@ -39,19 +47,20 @@ def test_create_job_application(client):
         "notes": "Excited about LLMs!"
     }
 
-    response = client.post("/applications/", json=new_job)
-    assert response.status_code == 200, response.text
+    response = await async_client.post("/applications/", json=new_job)
+    assert response.status_code == 201, response.text
 
     data = response.json()
     assert data["company"] == new_job["company"]
     assert data["position"] == new_job["position"]
     assert data["status"] == new_job["status"]
     assert data["applied_date"] == new_job["applied_date"]
-    isinstance(data["id"], int)
+    assert isinstance(data["id"], int)
 
 
 # This test verifies the logic of updating job details by the ID
-def test_update_job_application_by_id(client, db):
+@pytest.mark.anyio
+async def test_update_job_application_by_id(async_client, db_session):
     # Create the original job app in the DB
     job_app = JobApplication(
         company="OriginalCo",
@@ -62,9 +71,9 @@ def test_update_job_application_by_id(client, db):
         link="http://original.com",
         notes="initial notes"
     )
-    db.add(job_app)
-    db.commit()
-    db.refresh(job_app)
+    db_session.add(job_app)
+    await db_session.commit()
+    await db_session.refresh(job_app)
 
     # Prepare the update payload
     update_data = {
@@ -75,18 +84,19 @@ def test_update_job_application_by_id(client, db):
     }
 
     # Send PUT or PATCH request to update the job app
-    response = client.put(f"/applications/{job_app.id}/", json=update_data)
+    response = await async_client.put(f"/applications/{job_app.id}", json=update_data)
     assert response.status_code == 200
 
     # Verify the update was successful by fetching the updated object
-    get_response = client.get(f"/applications/{job_app.id}/")
+    get_response = await async_client.get(f"/applications/{job_app.id}")
     data = get_response.json()
     assert data["status"] == "interviewing"
     assert data["notes"] == "waiting for reply"
 
 
 # This test verifies the logic of updating job application by the ID
-def test_delete_job_application_by_id(client, db):
+@pytest.mark.anyio
+async def test_delete_job_application_by_id(async_client, db_session):
     # Create the original job app in the DB
     job_app = JobApplication(
         company="OriginalCo",
@@ -97,15 +107,18 @@ def test_delete_job_application_by_id(client, db):
         link="http://original.com",
         notes="initial notes"
     )
-    db.add(job_app)
-    db.commit()
-    db.refresh(job_app)
+    db_session.add(job_app)
+    await db_session.commit()
+    await db_session.refresh(job_app)
 
     # Send PUT or PATCH request to update the job app
-    response = client.delete(f"/applications/{job_app.id}")
+    response = await async_client.delete(f"/applications/{job_app.id}")
 
-    assert response.status_code == 200
+    assert response.status_code == 204
 
     # Check DB: job should not exist anymore
-    deleted_job = db.query(JobApplication).filter(JobApplication.id == job_app.id).first()
+    result = await db_session.execute(
+        select(JobApplication).where(JobApplication.id == job_app.id)
+    )
+    deleted_job = result.scalar_one_or_none()
     assert deleted_job is None

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,16 +1,9 @@
-from app.api.deps import get_db
+import pytest
+from httpx import AsyncClient
+from app.main import app  # The actual FastAPI app object being tested
 
 
-# Testing for dependency logic.
-def test_get_db(db):
-    gen = get_db()  # call your generator dependency
-    db = next(gen)  # get the yielded session
-
-    assert db is not None
-    from app.db.database import SessionLocal
-    assert isinstance(db, SessionLocal().__class__)
-
-    try:
-        next(gen)  # run cleanup
-    except StopIteration:
-        pass
+@pytest.mark.anyio
+async def test_async_db_dependency_injection(async_client: AsyncClient):
+    response = await async_client.get("/users/")
+    assert response.status_code in [200, 401, 403], f"Unexpected response: {response.status_code} - {response.text}"

--- a/tests/users/test_crud_users.py
+++ b/tests/users/test_crud_users.py
@@ -1,17 +1,21 @@
 # unit tests for database logic
 # CRUD Logic (No FastAPI involved)
+from unittest.mock import patch, MagicMock, AsyncMock
+
 import pytest
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from app.crud import user_crud
-from app.schemas import user_schemas
 from app.exceptions import (UserNotFoundException, DuplicateEmailException,
-                            DuplicateUsernameException, AppBaseException, ValidationError)
+                            DuplicateUsernameException, AppBaseException)
+from app.models import user_models
+from app.schemas import user_schemas
+from tests.conftest import AsyncTestingSessionLocal
 
-from unittest.mock import patch, MagicMock
 
-
-def test_create_user(db):
+@pytest.mark.anyio
+async def test_create_user(db_session):
     user = user_schemas.UserCreate(
         email="example@gmail.com",
         username="jared232",
@@ -19,12 +23,13 @@ def test_create_user(db):
         role="user",
         password="12320322dsek#€1"
     )
-    result = user_crud.create_user(db, user)
+    result = await user_crud.create_user(db_session, user)
     assert result.email == "example@gmail.com"
     assert result.username == "jared232"
 
 
-def create_invalid_user(db):
+@pytest.mark.anyio
+async def create_invalid_user(db_session):
     user = user_schemas.UserCreate(
         email="example@gmail.com",
         username="",
@@ -32,11 +37,12 @@ def create_invalid_user(db):
         role="user",
         password="12320322dsek#€1"
     )
-    result = user_crud.create_user(db, user)
+    result = await user_crud.create_user(db_session, user)
     assert result.email == "example@gmail.com"
 
 
-def test_create_user_with_duplicate_email(db):
+@pytest.mark.anyio
+async def test_create_user_with_duplicate_email(db_session):
     user1 = user_schemas.UserCreate(
         email="duplicate@gmail.com",
         username="userone",
@@ -44,7 +50,7 @@ def test_create_user_with_duplicate_email(db):
         role="user",
         password="password123"
     )
-    user_crud.create_user(db, user1)
+    await user_crud.create_user(db_session, user1)
 
     user2 = user_schemas.UserCreate(
         email="duplicate@gmail.com",  # same email!
@@ -54,11 +60,12 @@ def test_create_user_with_duplicate_email(db):
         password="password456"
     )
     with pytest.raises(DuplicateEmailException):
-        user_crud.create_user(db, user2)
-        db.commit()  # commit triggers the integrity error in SQLAlchemy
+        await user_crud.create_user(db_session, user2)
+        await db_session.commit()  # commit triggers the integrity error in SQLAlchemy
 
 
-def test_create_user_with_duplicate_username(db):
+@pytest.mark.anyio
+async def test_create_user_with_duplicate_username(db_session):
     user1 = user_schemas.UserCreate(
         email="unique1@gmail.com",
         username="sameusername",
@@ -66,7 +73,7 @@ def test_create_user_with_duplicate_username(db):
         role="user",
         password="password123"
     )
-    user_crud.create_user(db, user1)
+    await user_crud.create_user(db_session, user1)
 
     user2 = user_schemas.UserCreate(
         email="unique2@gmail.com",
@@ -76,11 +83,12 @@ def test_create_user_with_duplicate_username(db):
         password="password456"
     )
     with pytest.raises(DuplicateUsernameException):
-        user_crud.create_user(db, user2)
-        db.commit()
+        await user_crud.create_user(db_session, user2)
+        await db_session.commit()
 
 
-def test_get_user_with_username(db):
+@pytest.mark.anyio
+async def test_get_user_with_username(db_session):
     user_create = user_schemas.UserCreate(
         email="usernamegurl@gmail.com",
         username="usernamegurl",
@@ -88,21 +96,23 @@ def test_get_user_with_username(db):
         role="user",
         password="securepass"
     )
-    created_user = user_crud.create_user(db, user_create)
+    created_user = await user_crud.create_user(db_session, user_create)
 
-    fetched_user = user_crud.get_user_by_username(db, username=created_user.username)
+    fetched_user = await user_crud.get_user_by_username(db_session, username=created_user.username)
     assert fetched_user
     assert fetched_user.email == "usernamegurl@gmail.com"
 
 
-def test_create_user_with_invalid_username(db):
+@pytest.mark.anyio
+async def test_create_user_with_invalid_username(db_session):
     invalid_username = "wwwww"
 
     with pytest.raises(UserNotFoundException):
-        user_crud.get_user_by_username(db, username=invalid_username)  # get_user validates UUID format
+        await user_crud.get_user_by_username(db_session, username=invalid_username)  # get_user validates UUID format
 
 
-def test_get_user_with_uuid(db):
+@pytest.mark.anyio
+async def test_get_user_with_uuid(db_session):
     user_create = user_schemas.UserCreate(
         email="uuiduser@gmail.com",
         username="uuidgurl",
@@ -110,21 +120,23 @@ def test_get_user_with_uuid(db):
         role="user",
         password="securepass"
     )
-    created_user = user_crud.create_user(db, user_create)
+    created_user = await user_crud.create_user(db_session, user_create)
 
-    fetched_user = user_crud.get_user_by_id(db, user_id=created_user.id)
+    fetched_user = await user_crud.get_user_by_id(db_session, user_id=created_user.id)
     assert fetched_user
     assert fetched_user.email == "uuiduser@gmail.com"
 
 
-def test_create_user_with_invalid_uuid(db):
+@pytest.mark.anyio
+async def test_create_user_with_invalid_uuid(db_session):
     invalid_uuid = "not-a-valid-uuid"
 
     with pytest.raises(UserNotFoundException):
-        user_crud.get_user_by_id(db, user_id=invalid_uuid)  # get_user validates UUID format
+        await user_crud.get_user_by_id(db_session, user_id=invalid_uuid)  # get_user validates UUID format
 
 
-def test_update_user(db):
+@pytest.mark.anyio
+async def test_update_user(db_session):
     user_create = user_schemas.UserCreate(
         email="updateuser@gmail.com",
         username="updategurl",
@@ -132,17 +144,18 @@ def test_update_user(db):
         role="user",
         password="oldpass"
     )
-    user = user_crud.create_user(db, user_create)
+    user = await user_crud.create_user(db_session, user_create)
 
     update_data = user_schemas.UserUpdate(
         full_name="Updated User",
         password="newpass123"
     )
-    updated_user = user_crud.update_user(db, user.id, update_data)
+    updated_user = await user_crud.update_user(db_session, user.id, update_data)
     assert updated_user.full_name == "Updated User"
 
 
-def test_delete_user(db):
+@pytest.mark.anyio
+async def test_delete_user(db_session):
     user_create = user_schemas.UserCreate(
         email="deleteuser@gmail.com",
         username="deletegurl",
@@ -150,33 +163,71 @@ def test_delete_user(db):
         role="user",
         password="tobedeleted"
     )
-    user = user_crud.create_user(db, user_create)
+    user = await user_crud.create_user(db_session, user_create)
 
-    user_crud.delete_user(db, user.id)
-    with pytest.raises(UserNotFoundException):
-        user_crud.get_user_by_id(db, user.id)
+    await user_crud.delete_user(db_session, user.id)
+
+    # Fresh session to check true DB state
+    async with AsyncTestingSessionLocal() as verify_session:
+        result = await verify_session.execute(
+            select(user_models.User).where(user_models.User.id == user.id)
+        )
+        user_in_db = result.scalar_one_or_none()
+        assert user_in_db is None
 
 
-def test_update_user_integrity_error():
+@pytest.mark.anyio
+async def test_raw_delete_verification():
+    async with AsyncTestingSessionLocal() as session:
+        user = user_models.User(
+            email="rawdelete@gmail.com",
+            username="rawtest",
+            full_name="Raw Tester",
+            role="user",
+            hashed_password="hashed123"
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        user_id = user.id
+
+        await session.delete(user)
+        await session.commit()
+
+    # Re-check with fresh session
+    async with AsyncTestingSessionLocal() as verify_session:
+        result = await verify_session.execute(
+            select(user_models.User).where(user_models.User.id == user_id)
+        )
+        user_in_db = result.scalar_one_or_none()
+        assert user_in_db is None
+
+
+@pytest.mark.anyio
+async def test_update_user_integrity_error():
+    # db session needs async-mocking
     db = MagicMock()
-    user_id = 1
+    db.commit = AsyncMock(side_effect=IntegrityError('mock', 'mock', 'mock'))
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+
+    user_id = "some-id"
     mock_user = MagicMock()
 
     with patch('app.crud.user_crud.get_user_by_id', return_value=mock_user):
-        # Make commit raise IntegrityError to test rollback and exception
-        db.commit.side_effect = IntegrityError('mock', 'mock', 'mock')
-
         updated_data = user_schemas.UserUpdate(email="duplicate@example.com")
 
         with pytest.raises(AppBaseException) as excinfo:
-            user_crud.update_user(db, user_id, updated_data)
+            await user_crud.update_user(db, user_id, updated_data)
 
         db.rollback.assert_called_once()
         assert excinfo.value.status_code == 409
         assert "Database integrity error" in excinfo.value.detail
 
 
-def test_create_user_with_duplicate_data(db):
+@pytest.mark.anyio
+async def test_create_user_with_duplicate_data(db_session):
     user = user_schemas.UserCreate(
         email="duplicate@example.com",
         username="uniqueusername",
@@ -186,14 +237,14 @@ def test_create_user_with_duplicate_data(db):
     )
 
     # Create user once (should succeed)
-    user_crud.create_user(db, user)
+    await user_crud.create_user(db_session, user)
 
-    # Mock db.commit() on the session instance passed as 'db'
-    db_mock = MagicMock(wraps=db)
+    # Mock db_session.commit() on the session instance passed as 'db_session'
+    db_mock = MagicMock(wraps=db_session)
     db_mock.commit.side_effect = IntegrityError("duplicate key", None, None)
 
     with pytest.raises(AppBaseException) as exc_info:
-        user_crud.create_user(db_mock, user)
+        await user_crud.create_user(db_mock, user)
 
     assert exc_info.value.status_code == 409
     assert "Database integrity error" in exc_info.value.detail


### PR DESCRIPTION
_This PR finalizes the transition to fully async testing for the JobApplicationTracker app._

- Added async test cases for user and job routes using `AsyncClient`
- Replaced all sync CRUD and route tests with async equivalents
- Isolated test database state with table-level cleanup before each test
- Used `ASGITransport` for in-memory FastAPI testing to avoid network overhead
- Patched missing `await` keywords in CRUD methods and improved error handling
- Cleaned up old test.db and log files, switched to in-memory/temp DB approach
- Added `pytest.ini` to manage async event loop lifecycle